### PR TITLE
Fixed bug in gitlab_install.yml where fqdn is printed to file on gitl…

### DIFF
--- a/content/gitlab-install.yml
+++ b/content/gitlab-install.yml
@@ -27,6 +27,7 @@
         path: ./gitlab_server.out
         line: "https://{{ fqdn }}"
         create: yes
+      delegate_to: 127.0.0.1
 
     - name: Print Gitlab username to ./gitlab_users.out
       lineinfile:


### PR DESCRIPTION
…ab server instead of localhost