### PR TITLE
Fix link to next lab (in lab 0)

### DIFF
--- a/labs/lab-0/README.md
+++ b/labs/lab-0/README.md
@@ -84,6 +84,7 @@ export LAB_DIR=/home/student/ansible-roadshow
 export WORK_DIR=/home/student/work
 ```
 
+```
 End of lab
 ```
 [Go to the next lab, lab 1](../lab-1/README.md)


### PR DESCRIPTION
Link to next lab was broken in lab-0 README due to missing "```" before End of lab section.

The link was rendered as code.