### PR TITLE
Enable wildfly app service script

### DIFF
--- a/labs/lab-3/README.md
+++ b/labs/lab-3/README.md
@@ -57,7 +57,7 @@ cat << 'EOF' >$WORK_DIR/roles/wildflyapp/tasks/main.yml
 - name: Enable wildfly app service script
   systemd:
     name: wildflyapp
-    enabled: no
+    enabled: yes
     masked: no
 - name: Make sure the wildfly app service is running
   systemd: state=started name=wildflyapp


### PR DESCRIPTION
If task states it enables script, maybe it needs to be enabled?