### PR TITLE
Change systemd unit files location

### DIFF
--- a/labs/lab-3/README.md
+++ b/labs/lab-3/README.md
@@ -47,7 +47,7 @@ cat << 'EOF' >$WORK_DIR/roles/wildflyapp/tasks/main.yml
 - name: Create service script
   copy:
     src: roles/wildflyapp/files/wildflyapp.service
-    dest: /lib/systemd/system/wildflyapp.service
+    dest: /etc/systemd/system/wildflyapp.service
     owner: root
     group: root
     mode: 0644

--- a/labs/lab-5/README.md
+++ b/labs/lab-5/README.md
@@ -78,7 +78,7 @@ $
 - name: Create service script
   template:
     src: wildflyapp.template
-    dest: /lib/systemd/system/wildflyapp.service
+    dest: /etc/systemd/system/wildflyapp.service
     owner: root
     group: root
     mode: 0644

--- a/labs/lab-solutions/roles/wildflyapp/tasks/main.yml
+++ b/labs/lab-solutions/roles/wildflyapp/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Create service script
   template:
     src: roles/wildflyapp/files/wildflyapp.template
-    dest: /lib/systemd/system/wildflyapp.service
+    dest: /etc/systemd/system/wildflyapp.service
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
According to RedHat documentation, /usr/lib/systemd/system should be reserved
for unit files distributed with installed RPM packages.
Files added manually should be put under /etc/systemd/system.

See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/chap-Managing_Services_with_systemd#tabl-Managing_Services_with_systemd-Introduction-Units-Locations