### PR TITLE
Correct spelling mistake

### DIFF
--- a/labs/lab-3/README.md
+++ b/labs/lab-3/README.md
@@ -167,7 +167,7 @@ $ curl http://18.197.135.122:8080
 Howdy from unknown at 2018-08-30T22:25:09.897Z (from ip-172-31-25-165.eu-central-1.compute.internal)
 ```
 
-This is pretty cool, by using the simple role you just created, people can now get their own WilfFly servers, using a 7 lines long playbook.
+This is pretty cool, by using the simple role you just created, people can now get their own WildFly servers, using a 7 lines long playbook.
 
 ```
 ---


### PR DESCRIPTION
WilfFly --> WildFly