### PR TITLE
Use consistent spelling for NGINX

### DIFF
--- a/labs/lab-4/README.md
+++ b/labs/lab-4/README.md
@@ -1,18 +1,18 @@
 # Writing the load balancer playbook
 
-In the previous lab, we created two WildFly Swarm servers running our application. The next step is to setup a loadbalancer. We will use Nginx as the loadbalancer in this lab. Let's overview which part of the system you will be working on.
+In the previous lab, we created two WildFly Swarm servers running our application. The next step is to setup a load balancer. We will use NGINX as the load balancer in this lab. Let's overview which part of the system you will be working on.
 
 ![Overview of lab environment](../../content/images/app-arch2.png)
 
-A role has already been written for installing Nginx with Ansible. The role can be found at the Ansible Galaxy site (https://galaxy.ansible.com/nginxinc/nginx/). [Ansible Galaxy](https://galaxy.ansible.com) is the place where roles and modules are shared. 
+A role has already been written for installing NGINX with Ansible. The role can be found at the Ansible Galaxy site (https://galaxy.ansible.com/nginxinc/nginx/). [Ansible Galaxy](https://galaxy.ansible.com) is the place where roles and modules are shared.
 
- :thumbsup: As always be critical when using content on the internet. When it comes to roles on Ansible Galaxy it's easy to do a quick review of the general health of the role. 
+ :thumbsup: As always be critical when using content on the internet. When it comes to roles on Ansible Galaxy it's easy to do a quick review of the general health of the role.
 
 ![Evaluate quality of content](../../content/images/nginx.png)
 
  :thumbsup: Look at development activity of the role and number of downloads. Ansible Galaxy makes this evaluation easy by putting it on the front page of each role, as marked above. If there is not a lot of activity, there may be a risk that the role is not maintained.
 
-:boom: Now that we've seen that the nginx role seems solid. We need to install the role. Run:
+:boom: Now that we've seen that the `nginx` role seems solid. We need to install the role. Run:
 
 ```
 ansible-galaxy install --roles-path=$WORK_DIR/roles nginxinc.nginx
@@ -20,7 +20,7 @@ ansible-galaxy install --roles-path=$WORK_DIR/roles nginxinc.nginx
 
 and wait for the role to be installed. When that is done, we can use the role in our playbooks.
 
-:boom: To create a playbook which installs Nginx go to $WORK_DIR and create a new file named *lb.yml* with the following content:
+:boom: To create a playbook which installs NGINX go to $WORK_DIR and create a new file named *lb.yml* with the following content:
 
 ```
 ---
@@ -39,19 +39,19 @@ ansible-playbook -i hosts lb.yml
 ```
 Take a moment to appreciate how simple that was. You can again run the playbook multiple times, to ensure that this role is idempotent and that nothing changes the second time you run it.
 
-This installs _nginx_ on the servers in the lbservers group.
+This installs _NGINX_ on the servers in the lbservers group.
 
 :star: The attentive student saw an error message
-``` 
+```
 [WARNING]: Ignoring invalid attribute: Name
 ```
 This is due to a bug, which does not affect our run of this role, but ... what is the bug? And can you fix it?
 
 :boom: To verify the installation, in your web browser, go to: *http://$loadbalancer1-ip-address*.
 ![NGINX welcome page](../../content/images/nginx-welcome.png)
-You should get the Nginx default page, as shown above. Take some extra time to appreciate how very simple it was to install the NGINX software, even though you may never have done that before.
+You should get the NGINX default page, as shown above. Take some extra time to appreciate how very simple it was to install the NGINX software, even though you may never have done that before.
 
-Next step is to configure Nginx as a loadbalancer for the two wildflyapp servers. To do so, we'll add an additional role for the configuration. We follow the [best practises for Ansible directory layout](http://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html) and place tasks, handlers, and vars in separate directories. This is done so that it's easier to collaborate and maintain your work. 
+Next step is to configure NGINX as a loadbalancer for the two wildflyapp servers. To do so, we'll add an additional role for the configuration. We follow the [best practises for Ansible directory layout](http://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html) and place tasks, handlers, and vars in separate directories. This is done so that it's easier to collaborate and maintain your work.
 
 :boom: To create a boilerplate for our new role, which features these best practices, we use the ansible-galaxy command. Run below commands:
 
@@ -60,7 +60,7 @@ cd $WORK_DIR
 ansible-galaxy init roles/nginx-config
 ```
 
-:boom: First we'll create a handler for restarting the Nginx service in case of configuration changes. Define the handler in the file *$WORK_DIR/roles/nginx-config/handlers/main.yml* by replacing the content in the file with:
+:boom: First we'll create a handler for restarting the NGINX service in case of configuration changes. Define the handler in the file *$WORK_DIR/roles/nginx-config/handlers/main.yml* by replacing the content in the file with:
 
 ```
 ---
@@ -75,7 +75,7 @@ ansible-galaxy init roles/nginx-config
 
 ```
 ---
-- name: Configure nginx to listen for http
+- name: Configure NGINX to listen for http
   template:
     src: default.template
     dest: /etc/nginx/conf.d/default.conf
@@ -86,13 +86,13 @@ ansible-galaxy init roles/nginx-config
     enabled: yes
     masked: no
     state: started
-- name: Set and persist httpd_can_network_connect SELinux flag for nginx
+- name: Set and persist httpd_can_network_connect SELinux flag for NGINX
   seboolean:
     name: httpd_can_network_connect
     state: yes
     persistent: yes
 ```
-A template is used to setup the nginx http listener. The template ensures that your configuration file doesn't have to be static. In this case, you need to add the servers to loadbalance between. This is done by introducing a variable *wildfly_servers*, which you'll use when writing the template shortly. The configuration file is saved instead of the default.conf nginx template. Other approaches applies. Please refer to the nginx documentation for more information. If the configuration file is changed, the previously defined handler (*notify: restart-nginx-service*) ensures that the Nginx process is restarted. Finally a SELinux rule has to be setup, to allow Nginx to connect to port 8080.
+A template is used to setup the NGINX HTTP listener. The template ensures that your configuration file doesn't have to be static. In this case, you need to add the servers to loadbalance between. This is done by introducing a variable *wildfly_servers*, which you'll use when writing the template shortly. The configuration file is saved instead of the default.conf nginx template. Other approaches applies. Please refer to the NGINX documentation for more information. If the configuration file is changed, the previously defined handler (*notify: restart-nginx-service*) ensures that the NGINX process is restarted. Finally a SELinux rule has to be setup, to allow NGINX to connect to port 8080.
 
 :boom:  Define the variable *wildfly_servers* by replacing *$WORK_DIR/roles/nginx-config/vars/main.yml* with below content:
 
@@ -101,7 +101,7 @@ A template is used to setup the nginx http listener. The template ensures that y
 wildfly_servers: "{{ groups['wildflyservers'] }}"
 ```
 
-:boom: Edit $WORK_DIR/lb.yml to include the newly created role. *$WORK_DIR/lb.yml should now look as below:
+:boom: Edit *$WORK_DIR/lb.yml* to include the newly created role. *$WORK_DIR/lb.yml* should now look as below:
 
 ```
 ---
@@ -146,7 +146,7 @@ server {
 
 As you can see, the *wildfly_servers* variable is used to iterate over the servers with the WildFly application deployed.
 
-:boom: Apply the changes to the nginx configuration by running the playbook:
+:boom: Apply the changes to the NGINX configuration by running the playbook:
 
 ```
 cd $WORK_DIR
@@ -156,7 +156,7 @@ ansible-playbook -i hosts lb.yml
 The playbook should complete as such:
 ```
 PLAY RECAP *****************************************************************
-loadbalancer1              : ok=8    changed=3    unreachable=0    failed=0 
+loadbalancer1              : ok=8    changed=3    unreachable=0    failed=0
 ```
 
 :boom: Now test, that you can access the application on both application servers. For this we'll use a simple http client, called _curl_, in your terminal write:
@@ -192,9 +192,9 @@ ansible-playbook -i hosts main.yml
 The playbook should complete as such:
 ```
 PLAY RECAP ****************************************************************
-loadbalancer1              : ok=7    changed=0    unreachable=0    failed=0   
-wildfly1                   : ok=8    changed=0    unreachable=0    failed=0   
-wildfly2                   : ok=8    changed=0    unreachable=0    failed=0 
+loadbalancer1              : ok=7    changed=0    unreachable=0    failed=0
+wildfly1                   : ok=8    changed=0    unreachable=0    failed=0
+wildfly2                   : ok=8    changed=0    unreachable=0    failed=0
 ```
 
 ```

--- a/labs/lab-8/README.md
+++ b/labs/lab-8/README.md
@@ -1,4 +1,4 @@
-# Installing WildFly and Nginx from Tower
+# Installing WildFly and NGINX from Tower
 
 As the good developer you are, you now want to make sure your playbooks for provisioning the WildFly app is available for the whole organization to run and benefit from. This requires that you handle your Ansible content as code. This lab will describe how you can do so.
 
@@ -136,7 +136,7 @@ Congratulations, all your content is now in git. You can review it by looking in
 sed -i '/WORK_DIR/d' ~/.bashrc && echo "export WORK_DIR=/home/student/studentX-project" >> ~/.bashrc && . ~/.bashrc
 ```
 
-Now you need to instruct Ansible Tower to use the Nginx module. You could install the module on Ansible Tower as previously, but this would have the unwanted effect that all projects on the Ansible Tower server would rely on this module. Furthermore the Ansible Tower server now needs special care if you need to reinstall it. Instead we'll instruct Ansible Tower to include the Nginx module as part of our project. 
+Now you need to instruct Ansible Tower to use the NGINX module. You could install the module on Ansible Tower as previously, but this would have the unwanted effect that all projects on the Ansible Tower server would rely on this module. Furthermore the Ansible Tower server now needs special care if you need to reinstall it. Instead we'll instruct Ansible Tower to include the `nginx` module as part of our project.
 
 :boom: To do so, add a file *$WORK_DIR/roles/requirements.yml*, with the following content
 ```

--- a/labs/lab-9/README.md
+++ b/labs/lab-9/README.md
@@ -90,13 +90,13 @@ END OF TEST FRAMEWORK
 ```
 cd $WORK_DIR
 cat << 'EOF' >problem.yml
-- name: Create directory and restart Nginx 
+- name: Create directory and restart NGINX
   hosts: lbservers
   tasks: 
     - name: Create directory
       command: mkdir /tmp/logs
 
-    - name: Restart Nginx
+    - name: Restart NGINX
        shell: systemctl restart nginx
 EOF
 ```


### PR DESCRIPTION
It's slightly unclear what is the correct spelling: commercial upstream uses NGINX while open-source upstream seems to prefer nginx.