### PR TITLE
Change nginxinc.nginx role name to plain nginx.

### DIFF
--- a/labs/lab-4/README.md
+++ b/labs/lab-4/README.md
@@ -12,10 +12,19 @@ A role has already been written for installing NGINX with Ansible. The role can 
 
  :thumbsup: Look at development activity of the role and number of downloads. Ansible Galaxy makes this evaluation easy by putting it on the front page of each role, as marked above. If there is not a lot of activity, there may be a risk that the role is not maintained.
 
-:boom: Now that we've seen that the `nginx` role seems solid. We need to install the role. Run:
+:boom: Now that we've seen that the `nginx` role seems solid. We need to install the role. First create file for pulling required roles with ansible-galaxy:
 
 ```
-ansible-galaxy install --roles-path=$WORK_DIR/roles nginxinc.nginx
+cat << 'EOF' > $WORK_DIR/requirements.yml
+- src: nginxinc.nginx
+  name: nginx
+EOF
+```
+
+And do run the install command to pull all required external roles:
+
+```
+ansible-galaxy install --roles-path=$WORK_DIR/roles -r requirements.yml
 ```
 
 and wait for the role to be installed. When that is done, we can use the role in our playbooks.
@@ -29,7 +38,7 @@ and wait for the role to be installed. When that is done, we can use the role in
   become: true
   tasks:
   - include_role:
-      name: nginxinc.nginx
+      name: nginx
 ```
 
 :boom: Now, run the playbook to install NGINX on your server in the lbservers group, use the command
@@ -110,7 +119,7 @@ wildfly_servers: "{{ groups['wildflyservers'] }}"
   become: true
   tasks:
   - include_role:
-      name: nginxinc.nginx
+      name: nginx
   - include_role:
       name: nginx-config
 ```

--- a/labs/lab-8/README.md
+++ b/labs/lab-8/README.md
@@ -38,12 +38,12 @@ cp -R $WORK_DIR/* /home/student/studentX-project
 :boom: Next we need to tell git that we've added a bunch of new files.
 First we'll create a `.gitignore` file to avoid pushing unwanted files to the git repository.
 We don't want to have the `mypassword` file pushed to a public repository!
-The `nginxinc.nginx` comes from [Ansible Galaxy](https://galaxy.ansible.com/nginxinc/nginx/) and shouldn't be part of our repository either.
+The `nginx` comes from [Ansible Galaxy](https://galaxy.ansible.com/nginxinc/nginx/) and shouldn't be part of our repository either.
 Run below commands to do that (_replace X in studentX with your assigned number_):
 ```
 cd ~/studentX-project
 echo "mypassword" >> .gitignore
-echo "roles/nginxinc.nginx" >> .gitignore
+echo "roles/nginx" >> .gitignore
 ```
 
 :boom: We can now safely add all the files to git.
@@ -143,7 +143,7 @@ Now you need to instruct Ansible Tower to use the NGINX module. You could instal
 ---
 - src: https://github.com/nginxinc/ansible-role-nginx
   version: master
-  name: nginxinc.nginx
+  name: nginx
 ```
 
 :boom: Check in the change and you are ready to go. Do that by running below in a terminal:

--- a/labs/lab-solutions/lb.yml
+++ b/labs/lab-solutions/lb.yml
@@ -2,6 +2,6 @@
 - hosts: lbservers
   tasks:
   - include_role:
-      name: nginxinc.nginx
+      name: nginx
   - include_role:
       name: nginx-config


### PR DESCRIPTION
Fixes issue https://github.com/mglantz/ansible-roadshow/issues/149 by changing the name of role nginxinc.nginx to nginx.