### PR TITLE
Update README.md

### DIFF
--- a/labs/lab-2/README.md
+++ b/labs/lab-2/README.md
@@ -119,6 +119,7 @@ Please note _hosts: all_, the _all_ keyword ensures that when this playbook is r
 :boom: This will do the same as the previous lab, except the ping message is different. The ping message takes an argument *data*, which is the reply message from the ping module. You can now run the playbook with the command below. Notice, that we are now using the command 'ansible-playbook', not the command 'ansible' which we used in the previous lab.
 
 ```
+cd $WORK_DIR
 ansible-playbook -i hosts ping.yml
 ```
 


### PR DESCRIPTION
lab-2  does not enter "$WORK_DIR" directory. the student should be in this directory when done with lab-1, but earlier in this lab-2 document it's described to do "cat << 'EOF' >$WORK_DIR/ping.yml" - which contradicts that the student is already in the work dir. therefore, add cd workdir to be sure that the student is in the right spot.