### PR TITLE
Clarify IP address settings in hosts file

### DIFF
--- a/labs/lab-5/README.md
+++ b/labs/lab-5/README.md
@@ -30,7 +30,7 @@ wildfly1
 wildfly2
 ```
 
- :exclamation: As before, change xxx.yyy.zzz to the IP-addresses assigned to you.
+ :exclamation: Keep your current ip addresses that you set in Lab-1.
 
 Now Ansible will include all variables defined in *$WORK_DIR/group_vars/dev/* for the servers listed, each time the playbook is run.
 


### PR DESCRIPTION
It's more clear that the user should NOT change their IP address in their hosts file, than using this wording:
---
As before, change xxx.yyy.zzz to the IP-addresses assigned to you.
---
This could suggest to the user that he needs to change their IP address...