### PR TITLE
Indent in VIM for YAML

### DIFF
--- a/labs/lab-2/README.md
+++ b/labs/lab-2/README.md
@@ -54,7 +54,7 @@ Example playbook to install a Tomcat application server:
         state: "{{ tomcat_service_state }}"
 ```
 
-:exclamation: Please note that a playbook (YAML) is sensitive to indentation. That means that the playbook below has a serious syntax error and will not run.
+:exclamation: Please note that a playbook (YAML) is sensitive to indentation. That means that the playbook below has a serious syntax error and will not run. For VIM, you can add ```autocmd FileType yaml setlocal ts=2 sts=2 sw=2 expandtab``` to your ~/.vimrc file for easier editing of YAML.
 ```
 - name: Install Tomcat and ensure it runs
   hosts: tomcat-servers


### PR DESCRIPTION
Added tip for VIM users that you can insert one line in ~/.vimrc.