### PR TITLE
BUGFIX: delete playbook wasn't up to date

### DIFF
--- a/content/delete_instances.yml
+++ b/content/delete_instances.yml
@@ -1,5 +1,5 @@
 ---
-
+  
 - hosts:
     - "tag_identity_git"
     - "tag_identity_tower"
@@ -7,13 +7,13 @@
   connection: "local"
   gather_facts: false
   vars_files:
-    - vars.yml
+    - vars/vars.yml
 
   tasks:
   - name: "Remove tagged EC2 instances from security group"
     ec2:
       state: "running"
-      region: "{{ region }}"
+      region: "{{ ec2_region }}"
       instance_ids: "{{ ec2_id }}"
       group_id: ""
     delegate_to: "localhost"
@@ -21,7 +21,7 @@
   - name: "Terminate tagged EC2 instances"
     ec2:
       state: "absent"
-      region: "{{ region }}"
+      region: "{{ ec2_region }}"
       instance_ids: "{{ ec2_id }}"
       wait: true
     delegate_to: "localhost"
@@ -31,10 +31,22 @@
   connection: "local"
   gather_facts: false
   vars_files:
-    - vars.yml
+    - vars/vars.yml
   tasks:
-  - name: "Remove security group"
+  - name: "Remove security group for tower"
     ec2_group:
-      name: "{{ security_group }}"
-      region: "{{ region }}"
+      name: "{{ ec2_security_group_tower }}"
+      region: "{{ ec2_region }}"
+      state: "absent"
+
+  - name: "Remove security group for clients"
+    ec2_group:
+      name: "{{ ec2_security_group_client_systems }}"
+      region: "{{ ec2_region }}"
+      state: "absent"
+
+  - name: "Remove security group for gitlab"
+    ec2_group:
+      name: "{{ ec2_security_group_gitlab }}"
+      region: "{{ ec2_region }}"
       state: "absent"

--- a/labs/lab-5/README.md
+++ b/labs/lab-5/README.md
@@ -165,9 +165,9 @@ wildfly2                   : ok=8    changed=2    unreachable=0    failed=0
 :boom: And you should now be able to access the url of loadbalancer1 by running _curl_ again. Try it as shown below:
 ```
 $ curl -w '\n' http://<loadbalancer_IP>/
-Howdy from Red Hat at 2018-08-31T08:45:38.084Z (from <loadbalancer_FQDN>)
+Howdy from Red Hat at 2018-08-31T08:45:38.084Z (from <wildfly_FQDN>)
 $ curl -w '\n' http://<loadbalancer_IP>/
-Howdy from Red Hat at 2018-08-31T08:45:39.489Z (from <loadbalancer_FQDN>)
+Howdy from Red Hat at 2018-08-31T08:45:39.489Z (from <other_wildfly_FQDN>)
 ```
 Observe the changes. Hint, you are no longer getting an anonymous greeting.  If you get 404 errors from either Wild Fire server please wait a while and try again.
 


### PR DESCRIPTION
I added removal of all security groups.
Reference to vars.yaml wasn't correct. Fixed that.
Reference to ec2 variables weren't correct. Fixed that.